### PR TITLE
Missing appjs initialize call from example.

### DIFF
--- a/examples/octosocial/index.js
+++ b/examples/octosocial/index.js
@@ -2,6 +2,8 @@ var  app = require('../../index.js')
   , Github = require('github');
 
 var github = new Github({version: '3.0.0',debug:true})
+  // Initialize appjs before anything else
+  , app = appjs.init()
   // get screen dimension
   , screenWidth = app.screenWidth()
   , screenHeight = app.screenHeight()


### PR DESCRIPTION
The displayed cod example did not have the required appjs.init() call that the code example in the file had.
