### PR TITLE
fixed typos in One Minute Usage example in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ __AppJS 0.0.15 Distributables:__
 There is a complete example in the `examples` folder.
 
 ```javascript
-var appjs = require('appjs');
+var app = require('appjs');
 
 // Creates a new window. Its invisible until window.show() get called.
 // http://appjs/ is a special url. It is home for your application!
 var window = app.createWindow("http://appjs/",{autoResize:false});
 
 // Called when page load finishes.
-window.on("ready",function(){
+app.on("ready",function(){
     console.log("Event Ready called");
 
     // Runs a script in browser context.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ __AppJS 0.0.15 Distributables:__
 There is a complete example in the `examples` folder.
 
 ```javascript
-var app = require('appjs');
+var app = require('appjs').init();
 
 // Creates a new window. Its invisible until window.show() get called.
 // http://appjs/ is a special url. It is home for your application!


### PR DESCRIPTION
One Minute Usage example was missing calling init() after requiring appjs, and calling app.on() instead of window.on().  After making these changes locally, I was able to run example in Windows.
