### PR TITLE
force ia32 for builds under osx (for now)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -249,8 +249,11 @@
           'defines': [
             '__MAC__',
           ],
+          'cflags': [ '-m32' ],
+          'ldflags': [ '-m32' ],
           'xcode_settings': {
-            'OTHER_LDFLAGS':['-Xlinker -rpath -Xlinker @loader_path/']
+            'OTHER_LDFLAGS':['-Xlinker -rpath -Xlinker @loader_path/'],
+            'ARCHS': [ 'i386' ]
           },
           'link_settings': {
             'libraries': [


### PR DESCRIPTION
It will be _really_ nice when we can build 64 bit cef binaries.  Until then, these changes force 32bit on osx
