### PR TITLE
Update Request.js - Recognize req.body JSON format 

### DIFF
--- a/lib/router/Request.js
+++ b/lib/router/Request.js
@@ -14,7 +14,7 @@ function Request(request){
   this.pathname = parsed.pathname;
   this.hash = parsed.hash;
   this.params = parsed.query;
-  this.data = this.body = querystring.parse(request.post);
+  this.data = this.body = (  request.post.charAt(0) !== '{' )? querystring.parse(request.post) : JSON.parse(request.post);
   this.files = request.files;
 }
 


### PR DESCRIPTION
This forces send requests urlencoded format, otherwise it will create a wrong data.
Therefore, Req.body value should be maintained, so that it can be customized, for example sending JSON objects.
If you do not want to keep the original req.body at least recognize req.body JSON format.
