### PR TITLE
packaging support for appjs

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,12 +32,19 @@
           'files': [
             '<(module_root_dir)/node_modules/mime/',
           ]
+        },{
+          'destination': '<(module_root_dir)/app/data/node_modules/',
+          'files': [
+            '<(module_root_dir)/node_modules/appjs-package/',
+          ]
         },
         {
           'destination': '<(module_root_dir)/app/data/',
           'files': [
             '<(module_root_dir)/examples/hello-world/content/',
-            '<(module_root_dir)/examples/hello-world/app.js'
+            '<(module_root_dir)/examples/hello-world/app.js',
+'<(module_root_dir)/examples/hello-world/package.json'
+			
           ]
         }
       ],

--- a/data/linux/app.sh
+++ b/data/linux/app.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-./data/bin/node --harmony ./data/app.js 
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+$DIR/data/bin/node --harmony $DIR/data/app.js $1

--- a/examples/hello-world/app.js
+++ b/examples/hello-world/app.js
@@ -1,104 +1,162 @@
-var app = module.exports = require('appjs');
-
-app.serveFilesFrom(__dirname + '/content');
-
-var menubar = app.createMenu([{
-  label:'&File',
-  submenu:[
-    {
-      label:'E&xit',
-      action: function(){
-        window.close();
-      }
-    }
-  ]
-},{
-  label:'&Window',
-  submenu:[
-    {
-      label:'Fullscreen',
-      action:function(item) {
-        window.frame.fullscreen();
-        console.log(item.label+" called.");
-      }
-    },
-    {
-      label:'Minimize',
-      action:function(){
-        window.frame.minimize();
-      }
-    },
-    {
-      label:'Maximize',
-      action:function(){
-        window.frame.maximize();
-      }
-    },{
-      label:''//separator
-    },{
-      label:'Restore',
-      action:function(){
-        window.frame.restore();
-      }
-    }
-  ]
-}]);
-
-menubar.on('select',function(item){
-  console.log("menu item "+item.label+" clicked");
+/**
+* log any uncaught exceptions to disk in case user is not running from console.
+*/
+process.on('uncaughtException',function(e) {
+	require('fs').writeFile("error.log", e.message+"\n"+e.stack, function(err) {
+		if(err) {
+			console.log("error writing error log:",err);
+		} else {
+			console.log("uncaughtException:",e.stack);
+		}
+	}); 
 });
 
-var trayMenu = app.createMenu([{
-  label:'Show',
-  action:function(){
-    window.frame.show();
-  },
-},{
-  label:'Minimize',
-  action:function(){
-    window.frame.hide();
-  }
-},{
-  label:'Exit',
-  action:function(){
-    window.close();
-  }
-}]);
+var    fs = require('fs')
+	,path = require('path')
+	 ,app = require('appjs')
+;
 
-var statusIcon = app.createStatusIcon({
-  icon:'./data/content/icons/32.png',
-  tooltip:'AppJS Hello World',
-  menu:trayMenu
-});
+if (process.argv.length>2) {
+	var appPackage = require('appjs-package');
+	appPackage.getPackageInfo(process.argv[2],function(err,pInfo) {
+		if (err) throw err;
+		if (pInfo.router) {
+			//serve files using the package router.
+			app.router.use(pInfo.router);
+		}
+		app.readPackageFile = pInfo.readPackageFile;
+		//appPackage.launch(pInfo, app);
+		pInfo.readPackageFile(pInfo.launch,function(err,buffer) {
+			var path = require('path');
+			app.readPackageFile = pInfo.readPackageFile;
+			if (pInfo.isDir) {
+				app.serveFilesFrom(pInfo.path + '/content');
+			}
+			if (err) {
+				console.log("error:",err);
+			} else {
+				if (typeof iconsDir == "undefined") {
+					var iconsDir = __dirname + '/content/icons';
+				}
+				
+				var olddir = __dirname;
+				if (pInfo.isPackage) {
+					__dirname = path.dirname(pInfo.path);
+				} else {
+					__dirname = path.dirname(pInfo.launch);
+				}
+				eval(buffer.toString());
+				__dirname = olddir;
+			}
+		});
+		
+	});
+} else {
 
-var window = app.createWindow({
-  width  : 640,
-  height : 460,
-  icons  : __dirname + '/content/icons'
-});
+	var app = module.exports = require('appjs');
+	var iconsDir = __dirname + '/content/icons';
+	app.serveFilesFrom(__dirname + '/content');
 
-window.on('create', function(){
-  console.log("Window Created");
-  window.frame.show();
-  window.frame.center();
-  window.frame.setMenuBar(menubar);
-});
 
-window.on('ready', function(){
-  console.log("Window Ready");
-  window.process = process;
-  window.module = module;
+	var menubar = app.createMenu([{
+	  label:'&File',
+	  submenu:[
+		{
+		  label:'E&xit',
+		  action: function(){
+			window.close();
+		  }
+		}
+	  ]
+	},{
+	  label:'&Window',
+	  submenu:[
+		{
+		  label:'Fullscreen',
+		  action:function(item) {
+			window.frame.fullscreen();
+			console.log(item.label+" called.");
+		  }
+		},
+		{
+		  label:'Minimize',
+		  action:function(){
+			window.frame.minimize();
+		  }
+		},
+		{
+		  label:'Maximize',
+		  action:function(){
+			window.frame.maximize();
+		  }
+		},{
+		  label:''//separator
+		},{
+		  label:'Restore',
+		  action:function(){
+			window.frame.restore();
+		  }
+		}
+	  ]
+	}]);
 
-  function F12(e){ return e.keyIdentifier === 'F12' }
-  function Command_Option_J(e){ return e.keyCode === 74 && e.metaKey && e.altKey }
+	menubar.on('select',function(item){
+	  console.log("menu item "+item.label+" clicked");
+	});
 
-  window.addEventListener('keydown', function(e){
-    if (F12(e) || Command_Option_J(e)) {
-      window.frame.openDevTools();
-    }
-  });
-});
+	var trayMenu = app.createMenu([{
+	  label:'Show',
+	  action:function(){
+		window.frame.show();
+	  },
+	},{
+	  label:'Minimize',
+	  action:function(){
+		window.frame.hide();
+	  }
+	},{
+	  label:'Exit',
+	  action:function(){
+		window.close();
+	  }
+	}]);
 
-window.on('close', function(){
-  console.log("Window Closed");
-});
+	var statusIcon = app.createStatusIcon({
+	  icon:iconsDir+'/32.png',
+	  tooltip:'AppJS Hello World',
+	  menu:trayMenu
+	});
+
+	var window = app.createWindow({
+	  width  : 640,
+	  height : 460,
+	  icons  : iconsDir
+	});
+
+	window.on('create', function(){
+	  console.log("Window Created");
+	  window.frame.show();
+	  window.frame.center();
+	  window.frame.setMenuBar(menubar);
+	});
+
+	window.on('ready', function(){
+	  console.log("Window Ready");
+	  window.process = process;
+	  window.module = module;
+
+	  function F12(e){ return e.keyIdentifier === 'F12' }
+	  function Command_Option_J(e){ return e.keyCode === 74 && e.metaKey && e.altKey }
+
+	  window.addEventListener('keydown', function(e){
+		if (F12(e) || Command_Option_J(e)) {
+		  window.frame.openDevTools();
+		}
+	  });
+	});
+
+	window.on('close', function(){
+	  console.log("Window Closed");
+	});
+
+}

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -4,13 +4,6 @@
     "moduleUrl": "http://appjs.delightfulsoftware.com/node_modules/",
     "appUpdateUrl": "http://appjs.delightfulsoftware.com/example-apps/helloWorld.appjs",
     "appdeps": {
-        "iconv": {
-            "name": "iconv",
-            "version": "1.2.3",
-            "platforms": {
-                "win32": "win32"
-            }
-        },
         "mime": {
             "name": "mime",
             "version": "1.2.5",
@@ -20,21 +13,20 @@
         },
         "appjs-win32": {
             "name": "appjs-win32",
-            "version": "0.0.19",
-            "platforms": {
-                "win32": "win32"
-            }
-        },
-        "adm-zip": {
-            "name": "adm-zip",
-            "version": "0.1.5",
+            "version": "0.0.20",
             "platforms": {
                 "win32": "win32"
             }
         },
         "appjs": {
             "name": "appjs",
-            "version": "0.0.19",
+            "version": "0.0.20",
+            "platforms": {
+                "win32": "win32"
+            }
+        },"appjs-package": {
+            "name": "appjs-package",
+            "version": "0.1.14",
             "platforms": {
                 "win32": "win32"
             }

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,0 +1,43 @@
+{
+    "name": "appjs-runtime",
+    "version": 0.1,
+    "moduleUrl": "http://appjs.delightfulsoftware.com/node_modules/",
+    "appUpdateUrl": "http://appjs.delightfulsoftware.com/example-apps/helloWorld.appjs",
+    "appdeps": {
+        "iconv": {
+            "name": "iconv",
+            "version": "1.2.3",
+            "platforms": {
+                "win32": "win32"
+            }
+        },
+        "mime": {
+            "name": "mime",
+            "version": "1.2.5",
+            "platforms": {
+                "win32": "win32"
+            }
+        },
+        "appjs-win32": {
+            "name": "appjs-win32",
+            "version": "0.0.19",
+            "platforms": {
+                "win32": "win32"
+            }
+        },
+        "adm-zip": {
+            "name": "adm-zip",
+            "version": "0.1.5",
+            "platforms": {
+                "win32": "win32"
+            }
+        },
+        "appjs": {
+            "name": "appjs",
+            "version": "0.0.19",
+            "platforms": {
+                "win32": "win32"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch modifies the example application so that if you pass it an argument with a path to a .appjs file then it should run the application from inside the package. The majority of the logic is provided by appjs-package module.

npm install appjs-package in the root directory to get the latest implementation.

I have tested extensively on windows and have example apps you can test it with here:  http://appjs.delightfulsoftware.com/example-apps/

/Simon
