### PR TITLE
NODE_PATH was not exported so after execing the application we lose the variable

### DIFF
--- a/package/mac/AppBundle.skel.app/Contents/MacOS/appjs
+++ b/package/mac/AppBundle.skel.app/Contents/MacOS/appjs
@@ -5,5 +5,5 @@ function realpath_f () {(cd "$1" && echo "$(pwd -P)")}
 basedir="$( realpath_f `dirname ${0}` )";
 basedir="$( dirname ${basedir} )";
 
-NODE_PATH="${basedir}/MacOS/node_modules";
+export NODE_PATH="${basedir}/MacOS/node_modules";
 exec $basedir/MacOS/bin/node --harmony $basedir/Resources/app.js;


### PR DESCRIPTION
Couldn't get the Mac packager working.  After exporting the NODE_PATH variable it worked as expected.
