### PR TITLE
Fix for compiling on 10.6

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,17 @@
+## To Build
+
+### Mac
+
+These instructions work on 10.6
+
+clone the repository
+
+    cd appjs
+
+    npm install mime
+
+Download `node-v0.8.15-darwin-x86.tar.gz`
+
+extract and grab the `bin/node` executable and stick it in `data/mac/node-bin/`
+
+    node-gyp rebuild --arch i386 -j 4 # the space matters after the -j

--- a/binding.gyp
+++ b/binding.gyp
@@ -286,7 +286,7 @@
           'link_settings': {
             'libraries': [
                '<(module_root_dir)/deps/cef/Release/lib.target/libcef.dylib',
-               '<(module_root_dir)/build/Release/cef_dll_wrapper.node',
+               '<(module_root_dir)/build/Release/cef_dll_wrapper.a',
                '-lobjc'
              ]
           }


### PR DESCRIPTION
Some fixes to compile under 10.6

I haven't tested compiling under any other version than 10.6 so there might be some breakage there.

I also added some documentation on how to build in the BUILDING.md file.  Again these instructions are strictly for 10.6, but could work with other versions.
