### PR TITLE
Update lib/bindings.js Node 64 bit is only supported on Linux

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -9,14 +9,10 @@ if (version < 0.8) {
   throw new Error("AppJS requires Node.js v0.8");
 }
 
-if (platform == 'darwin' && arch === 'x64') {
-  throw new Error("AppJS requires Node.js 32bit");
-}
-
 var bindingsPath = __dirname + '/../bindings/'+platform+'/'+arch+'/appjs.node';
 
 if (!fs.existsSync(bindingsPath)) {
-  throw new Error("AppJS .node file not found");
+  throw new Error("appjs.node file not found at: " + path.resolve(bindingsPath) + " \n *** AppJS Requires 32 bit node on all platforms except for Linux. ***");
 }
 bindingsPath = require.resolve(bindingsPath);
 


### PR DESCRIPTION
AppJS only supports 64 bit node on Linux. The only time appjs.node will not be found is if the platform is unsupported or if the user has changed/deleted files they should not have.

There is no need to have multiple checks for which platform and arch we're dealing with. Either appjs.node is found or it isn't, that's taken care of by having the directory structure of the bindings reflect the platform and architecture.

Note that I'm using Windows 7 x64 but the platform still says win32. It's a generic name for windows platform, the arch is accurate.
