### PR TITLE
Memory Leaks in V8StringToChar and its invocations

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -334,6 +334,7 @@
             'VCLinkerTool': {
               'LinkTimeCodeGeneration': 1, # link-time code generation
               'OptimizeReferences': 2, # /OPT:REF
+              'AdditionalOptions': "/FORCE:MULTIPLE",
               'EnableCOMDATFolding': 2, # /OPT:ICF
               'LinkIncremental': 1, # disable incremental linking
             },
@@ -355,7 +356,7 @@
               'GdiPlus.lib',
               'Shlwapi.lib',
               '<(module_root_dir)/deps/cef/lib/Release/libcef.lib',
-              '<(module_root_dir)/build/Release/lib/libcef_dll_wrapper.lib'
+              '<(module_root_dir)/build/Release/libcef_dll_wrapper.lib'
             ],
           },
         }]

--- a/src/appjs_window.cpp
+++ b/src/appjs_window.cpp
@@ -187,7 +187,7 @@ v8::Handle<Value> Window::SendSync(const Arguments& args) {
 
         // convert Node V8 string to Cef V8 string
         CefV8ValueList argsOut;
-        argsOut.push_back(CefV8Value::CreateString(V8StringToChar(args[0]->ToString())));
+        argsOut.push_back(CefV8Value::CreateString(&*(V8StringToChar(args[0]->ToString()))));
 
         // execute window.appjs fuction, passing in the string,
         // then convert the return value from a CefValue to a Node V8 string
@@ -218,7 +218,7 @@ v8::Handle<Value> Window::SetIcon(const Arguments& args) {
 #if defined(__WIN__)
   window->SetIcon(enumVal, V8StringToWCHAR(args[1]->ToString()));
 #else
-  window->SetIcon(enumVal, V8StringToChar(args[1]->ToString()));
+  window->SetIcon(enumVal, (&*V8StringToChar(args[1]->ToString()));
 #endif
 
   return scope.Close(args.This());

--- a/src/appjs_window.cpp
+++ b/src/appjs_window.cpp
@@ -3,7 +3,6 @@
 #include "appjs_window.h"
 #include "includes/cef_handler.h"
 #include "includes/util.h"
-#include <memory>
 
 extern CefRefPtr<ClientHandler> g_handler;
 

--- a/src/appjs_window.cpp
+++ b/src/appjs_window.cpp
@@ -3,6 +3,7 @@
 #include "appjs_window.h"
 #include "includes/cef_handler.h"
 #include "includes/util.h"
+#include <memory>
 
 extern CefRefPtr<ClientHandler> g_handler;
 
@@ -154,8 +155,6 @@ v8::Handle<Value> Window::Resize(const Arguments& args) {
   return scope.Close(args.This());
 }
 
-
-
 v8::Handle<Value> Window::RunInBrowser(const Arguments& args) {
   HandleScope scope;
 
@@ -187,7 +186,8 @@ v8::Handle<Value> Window::SendSync(const Arguments& args) {
 
         // convert Node V8 string to Cef V8 string
         CefV8ValueList argsOut;
-        argsOut.push_back(CefV8Value::CreateString(&*(V8StringToChar(args[0]->ToString()))));
+        std::unique_ptr<char[]> uniPtr = V8StringToChar(args[0]->ToString());
+        argsOut.push_back(CefV8Value::CreateString(uniPtr.get()));
 
         // execute window.appjs fuction, passing in the string,
         // then convert the return value from a CefValue to a Node V8 string
@@ -218,7 +218,8 @@ v8::Handle<Value> Window::SetIcon(const Arguments& args) {
 #if defined(__WIN__)
   window->SetIcon(enumVal, V8StringToWCHAR(args[1]->ToString()));
 #else
-  window->SetIcon(enumVal, (&*V8StringToChar(args[1]->ToString()));
+  std::unique_ptr<char[]> uniPtr = V8StringToChar(args[1]->ToString());
+  window->SetIcon(enumVal, uniPtr.get());
 #endif
 
   return scope.Close(args.This());

--- a/src/includes/cef_scheme_handler.cpp
+++ b/src/includes/cef_scheme_handler.cpp
@@ -115,8 +115,8 @@ v8::Handle<Value> AppjsSchemeHandler::NodeCallback(const Arguments& args) {
   AutoLock lock_scope(me);
 
   me->status_      = args[0]->NumberValue();
-  me->status_text_ = V8StringToChar(args[1]->ToString());
-  me->mime_type_   = V8StringToChar(args[2]->ToString());
+  me->status_text_ = (&*V8StringToChar(args[1]->ToString()));
+  me->mime_type_   = (&*V8StringToChar(args[2]->ToString()));
   me->data_        = node::Buffer::Data(args[4]->ToObject());
   me->data_length_ = node::Buffer::Length(args[4]->ToObject());
 
@@ -127,8 +127,8 @@ v8::Handle<Value> AppjsSchemeHandler::NodeCallback(const Arguments& args) {
   for(uint i = 0; i < names->Length(); i++) {
     me->headers_.insert(
       std::pair<CefString,CefString>(
-        V8StringToChar(names->Get(i)),
-        V8StringToChar(headers->Get(i))
+        (&*V8StringToChar(names->Get(i))),
+        (&*V8StringToChar(headers->Get(i)))
       )
     );
   }

--- a/src/includes/cef_scheme_handler.cpp
+++ b/src/includes/cef_scheme_handler.cpp
@@ -115,8 +115,8 @@ v8::Handle<Value> AppjsSchemeHandler::NodeCallback(const Arguments& args) {
   AutoLock lock_scope(me);
 
   me->status_      = args[0]->NumberValue();
-  me->status_text_ = (&*V8StringToChar(args[1]->ToString()));
-  me->mime_type_   = (&*V8StringToChar(args[2]->ToString()));
+  me->status_text_ = V8StringToChar(args[1]->ToString()).release();
+  me->mime_type_   = V8StringToChar(args[2]->ToString()).release();
   me->data_        = node::Buffer::Data(args[4]->ToObject());
   me->data_length_ = node::Buffer::Length(args[4]->ToObject());
 
@@ -125,10 +125,12 @@ v8::Handle<Value> AppjsSchemeHandler::NodeCallback(const Arguments& args) {
   Local<Array> headers = Local<Array>::Cast(headerSets->Get(String::NewSymbol("headers")));
 
   for(uint i = 0; i < names->Length(); i++) {
+    std::unique_ptr<char[]> uniPtrName = V8StringToChar(names->Get(i));
+    std::unique_ptr<char[]> uniPtrHeader = V8StringToChar(headers->Get(i));
     me->headers_.insert(
       std::pair<CefString,CefString>(
-        (&*V8StringToChar(names->Get(i))),
-        (&*V8StringToChar(headers->Get(i)))
+        uniPtrName.get(),
+        uniPtrHeader.get()
       )
     );
   }

--- a/src/includes/cef_sync_handler.cpp
+++ b/src/includes/cef_sync_handler.cpp
@@ -3,7 +3,6 @@
 #include "includes/cef_sync_handler.h"
 #include "includes/util.h"
 #include "native_window/native_window.h"
-#include <memory>
 
 namespace appjs {
 

--- a/src/includes/cef_sync_handler.cpp
+++ b/src/includes/cef_sync_handler.cpp
@@ -3,6 +3,7 @@
 #include "includes/cef_sync_handler.h"
 #include "includes/util.h"
 #include "native_window/native_window.h"
+#include <memory>
 
 namespace appjs {
 
@@ -21,8 +22,8 @@ bool AppjsSyncHandler::Execute(const CefString& name,
     Local<Function> handler = Local<Function>::Cast(window->Get(String::NewSymbol("onmessage")));
     Local<Value> result = handler->Call(window, 1, argv);
     if (result->IsString()) {
-      char* plain = (&*V8StringToChar(result->ToString()));
-      retval = CefV8Value::CreateString(plain);
+      std::unique_ptr<char[]> uniPtr = V8StringToChar(result->ToString());
+      retval = CefV8Value::CreateString(uniPtr.get());
     }
   }
   return true;

--- a/src/includes/cef_sync_handler.cpp
+++ b/src/includes/cef_sync_handler.cpp
@@ -21,7 +21,7 @@ bool AppjsSyncHandler::Execute(const CefString& name,
     Local<Function> handler = Local<Function>::Cast(window->Get(String::NewSymbol("onmessage")));
     Local<Value> result = handler->Call(window, 1, argv);
     if (result->IsString()) {
-      char* plain = V8StringToChar(result->ToString());
+      char* plain = (&*V8StringToChar(result->ToString()));
       retval = CefV8Value::CreateString(plain);
     }
   }

--- a/src/includes/util.cpp
+++ b/src/includes/util.cpp
@@ -2,15 +2,16 @@
 
 namespace appjs {
 
+
 using namespace v8;
 
-char* V8StringToChar(Handle<String> str) {
+std::shared_ptr<char> V8StringToChar(Handle<String> str) {
   int len = str->Utf8Length();
   char* buf = new char[len + 1];
   str->WriteUtf8(buf, len + 1);
-  return buf;
+  return std::shared_ptr<char>(buf, ArrayDeleter<char>());
 }
-char* V8StringToChar(Local<Value> val) {
+std::shared_ptr<char> V8StringToChar(Local<Value> val) {
   return V8StringToChar(val->ToString());
 }
 
@@ -50,7 +51,7 @@ Local<String> CefStringToV8(const CefString& str) {
 }
 
 CefRefPtr<CefV8Value> V8StringToCef(Handle<Value> str){
-  return CefV8Value::CreateString(V8StringToChar(str->ToString()));
+  return CefV8Value::CreateString(&*V8StringToChar(str->ToString()));
 }
 
 Settings::Settings(Persistent<Object> settings):settings_(settings){};
@@ -77,7 +78,7 @@ int Settings::getInteger(const char* property, int defaultValue = 0) {
 
 char* Settings::getString(const char* property, char* defaultValue = "") {
   Local<Value> tmp = get(property);
-  return (tmp->IsString())? V8StringToChar(get(property)->ToString()) : defaultValue;
+  return (tmp->IsString())? (&*V8StringToChar(get(property)->ToString())) : defaultValue;
 }
 
 #ifdef __WIN__

--- a/src/includes/util.h
+++ b/src/includes/util.h
@@ -4,6 +4,7 @@
 #include "include/cef_base.h"
 #include "include/cef_v8.h"
 #include <node.h>
+#include <memory>
 
 #define ARRAY_SIZE(a) \
   ((sizeof(a) / sizeof(*(a))) / \
@@ -11,12 +12,19 @@
 
 namespace appjs {
 
+template <class T>
+class ArrayDeleter {
+public:
+    void operator () (T* d) const
+    { delete [] d; }
+};
+
 #if defined(__WIN__)
 WCHAR* V8StringToWCHAR(v8::Handle<v8::String> str);
 #endif
 
-char* V8StringToChar(v8::Handle<v8::String> str);
-char* V8StringToChar(v8::Local<v8::Value> val);
+std::shared_ptr<char> V8StringToChar(v8::Handle<v8::String> str);
+std::shared_ptr<char> V8StringToChar(v8::Local<v8::Value> val);
 char* V8StringToFunctionChar(v8::Handle<v8::String> str);
 v8::Local<v8::String> CefStringToV8(const CefString& str);
 CefRefPtr<CefV8Value> V8StringToCef(v8::Handle<v8::Value> str);

--- a/src/includes/util.h
+++ b/src/includes/util.h
@@ -12,19 +12,12 @@
 
 namespace appjs {
 
-template <class T>
-class ArrayDeleter {
-public:
-    void operator () (T* d) const
-    { delete [] d; }
-};
-
 #if defined(__WIN__)
 WCHAR* V8StringToWCHAR(v8::Handle<v8::String> str);
 #endif
 
-std::shared_ptr<char> V8StringToChar(v8::Handle<v8::String> str);
-std::shared_ptr<char> V8StringToChar(v8::Local<v8::Value> val);
+std::unique_ptr<char[]> V8StringToChar(v8::Handle<v8::String> str);
+std::unique_ptr<char[]> V8StringToChar(v8::Local<v8::Value> val);
 char* V8StringToFunctionChar(v8::Handle<v8::String> str);
 v8::Local<v8::String> CefStringToV8(const CefString& str);
 CefRefPtr<CefV8Value> V8StringToCef(v8::Handle<v8::Value> str);


### PR DESCRIPTION
Following on the issue https://github.com/appjs/appjs/issues/382 I have used:
1. std::unique_ptr instead of raw pointers.
2. Invocations of V8StringToChar has been changed to either get() or release(), depending upon what i thought was required at that position.

Binding.gyp has been changed to work at my Local repo. That does not come as part of these changes.
