### PR TITLE
Add deprecation notice to the front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@
     <!-- Main hero unit for a primary marketing message or call to action -->
     <header class="hero-unit">
       <div class="inner">
-        <h1>Build Desktop Applications</h1>
-        <p>for Linux, Windows and Mac using HTML, CSS and Javascript</p>
+        <h1>Deprecation Notice</h1>
+        <p>AppJS project has not been actively developed for several months. Please check out <a href="https://github.com/sihorton/appjs-deskshell/">Deskshell</a> instead.</a></p>
         <p>
           <a href="#download" class="btn btn-warning btn-large">Download AppJS (v0.0.20)</a>
           <a href="https://github.com/appjs/appjs/wiki" class="btn btn-large btn-info">Read Documentation</a>


### PR DESCRIPTION
Looking at [appjs.com](http://appjs.com/), it's almost impossible to tell that this project is deprecated. This pull request will make it obvious, and it will also point users towards deskshell.
