### PR TITLE
Update deprecation notice and fix cname

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-appjs.org
+appjs.com

--- a/index.html
+++ b/index.html
@@ -51,11 +51,7 @@
     <header class="hero-unit">
       <div class="inner">
         <h1>Deprecation Notice</h1>
-        <p>AppJS project has not been actively developed for several months. Please check out <a href="https://github.com/sihorton/appjs-deskshell/">Deskshell</a> instead.</a></p>
-        <p>
-          <a href="#download" class="btn btn-warning btn-large">Download AppJS (v0.0.20)</a>
-          <a href="https://github.com/appjs/appjs/wiki" class="btn btn-large btn-info">Read Documentation</a>
-        </p>
+        <p>AppJS project has not been actively developed for a few years. Please check out <a href='nwjs.io'>NW.js</a> or <a href='http://electron.atom.io/'>Electron</a> instead.</p>
       </div>
     </header>
 


### PR DESCRIPTION
Supercedes #423.

I discovered that there already was a deprecation notice -- the CNAME file is broken. I double checked, and appjs.com is served by GitHub pages, so I'm hoping you'll pull this.
